### PR TITLE
RexMatch object for last regex evaluated + other small fixes

### DIFF
--- a/rex.py
+++ b/rex.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 import re
 import operator
 
@@ -28,7 +27,6 @@ class RexMatch(dict):
         return unicode(self[0]) if self[0] else u''
 
 
-
 class Rex(object):
     FLAGS = {
         'd': re.DEBUG,
@@ -47,15 +45,14 @@ class Rex(object):
         self.replacement = replacement
         self.re = re.compile(self.pattern, self.flags)
 
-
     def __process(self, text):
         if self.action == 'm':
             result = RexMatch()
             match = self.re.search(text)
             if match is not None:
+                rex.group = result
                 result[0] = match.group()
-                for i, m in enumerate(match.groups()):
-                    result[i + 1] = m
+                result.update(enumerate(match.groups(), start=1))
                 result.update(match.groupdict())
             return result
         elif self.action == 's':
@@ -106,6 +103,7 @@ def rex(expression, text=None, cache=True):
         return text == rex_obj
     else:
         return rex_obj
+rex.group = RexMatch()
 
 
 def rex_clear_cache():

--- a/tests.py
+++ b/tests.py
@@ -174,6 +174,10 @@ class TestRex(unittest.TestCase):
         self.assertEqual(rm.get('a', 'b'), 'b')
         self.assertEqual(rm.get('c', 'b'), 'b')
 
+    def test_rex_group(self):
+        m = "This is cat! A kitten is a cat but not a dog." == rex('/[a-z]+!.*(kitten\s\S{2}).*but.*(dog)\./')
+        self.assertEqual(m, rex.group)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Since the syntax is borrowed from Perl's it would seem appropriate to have some way to reference the capturing groups of the last regex evaluated. Currently `rex` needs to save the `RexMatch` object in a variable to allow access to its captured groups.

In Perl you can just do,

``` perl
if ("Your ticket number: XyZ-1047. Have fun!" =~ /[a-z]{3}-(\d{4})/i){
    print $1;
}
```

I added similar functionality,

``` python
from rex import rex
if "Your ticket number: XyZ-1047. Have fun!" == rex("/[a-z]{3}-(\d{4})/i"):
    print rex.group[1]
```

`group` is an attribute of `rex` function object but can just as easily be global if you prefer. I only choose this way because it seemed like you were encouraging `from rex import rex` style import.

Also fixed PEP8 spacing issues, removed unused import, and cleaned up `RexMatch` updating.
