### PR TITLE
RexMatch object for last regex

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ python-rex changelog
 
 dev
 ---
+* Added attribute "group" to rex function object holding last regex's RexMatch object
 * RexMatch bug fix (default value when using get())
 
 0.3.1


### PR DESCRIPTION
Added line under dev heading - is this correct?

For https://github.com/cypreess/python-rex/pull/3
