### PR TITLE
Make Rex objects callable to allow "orthodox" mode with "precompiled" rex instances

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,5 +162,12 @@ you can use "orthodox mode" of rex. Just put the string to match/substitute agai
     >>> rex("s/cat/dog/", "This is a cat")
     'This is a dog'
 
+Additionally Rex objects are callable. This is especially useful in situations where you need to process many values
+against the same regular expression::
 
-
+    >>> my_re = rex("/foo/")
+    >>> for thing in ["foobar", "bar", "barfoo"]:
+    ...     print bool(my_re(thing))
+    True
+    False
+    True

--- a/rex.py
+++ b/rex.py
@@ -61,6 +61,9 @@ class Rex(object):
     def __eq__(self, other):
         return self.__process(other)
 
+    def __call__(self, text):
+        return self.__process(text)
+
 
 def rex(expression, text=None, cache=True):
     rex_obj = REX_CACHE.get(expression, None)

--- a/tests.py
+++ b/tests.py
@@ -107,6 +107,14 @@ class TestRex(unittest.TestCase):
                          rex('/([0-9-]+) (?P<t>[0-9-]+)/', "Aa 9-9 88 xx")[
                              'tttt'])
 
+    def test_m_true_call(self):
+        r = rex('/([0-9-]+) (?P<t>[0-9-]+)/')
+        self.assertTrue(r("Aa 9-9 88 xx"))
+
+    def test_m_false_call(self):
+        r = rex('/([0-9-]+) (?P<t>[0-9-]+)/')
+        self.assertFalse(r("Aa 9-9  xx"))
+
     def test_s(self):
         self.assertEqual('This is a dog', "This is a cat" == rex('s/cat/dog/'))
 


### PR DESCRIPTION
It would be nice if this worked:

``` python
>>> r = rex("/[Ss]ome.pattern/")
>>> r("Some pattern")
{0: 'Some pattern'}
```
