### PR TITLE
Extra g flag returns the list of all matched strings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,12 @@ Every **Rex** pattern as in Perl patterns allows to suffix some flags, e.g. ``re
 * ``u`` - re.UNICODE
 * ``x`` - re.VERBOSE
 
+Extra flags
+-----------
+
+Extra ``g`` flags means that **Rex** returns the list of all matched strings.
+
+
 Caching
 -------
 

--- a/rex.py
+++ b/rex.py
@@ -1,6 +1,5 @@
 import re
 import operator
-from six.moves import reduce
 import six
 
 REX_CACHE = {}

--- a/test_rex.py
+++ b/test_rex.py
@@ -122,6 +122,12 @@ def test_m_false_call():
     assert not r("Aa 9-9  xx")
 
 
+def test_m_g():
+    assert (("Aa 9-9 88 xx" == rex('/(\d)/g')) == ['9', '9', '8', '8'])
+    assert (("Aa 9-9 88 xx" == rex('/([aA])/g')) == ['A', 'a'])
+    assert (("Aa 9-9 88 xx" == rex('/(ttt)/g')) == [])
+
+
 def test_s():
     s = ("This is a cat" == rex('s/cat/dog/'))
     assert s == 'This is a dog'


### PR DESCRIPTION
```
>>> "ala ma kota" == rex('/(\w+)/g')
['ala', 'ma', 'kota']
```

The same in Perl:

```
perl> "ala ma kota" =~ /(\w+)/g;
("ala", "ma", "kota")
```
